### PR TITLE
Fix broken links in head-nav

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -25,10 +25,10 @@ TRANSLATIONS = {
 }
 NAVIGATION_LINKS = {
     DEFAULT_LANG: (
-#		('https://wiki.funkfeuer.at/', 'Wiki'),
-        ('/housing/', 'Server Housing'),
-        ('/presse/', 'Presse'),
-		('/impressum/', 'Impressum'),
+	('https://wiki.funkfeuer.at/', 'Wiki'),
+#        ('/housing/', 'Server Housing'),
+        ('https://wiki.funkfeuer.at/wiki/0xFF_in_der_Presse', 'Presse'),
+	('/impressum/', 'Impressum'),
 	),
 }
 


### PR DESCRIPTION
Since there is no homepage for housing remove that link. Add Wiki instead, which is alive and holds further information.